### PR TITLE
fix: correct type declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: [20, 22, 24]
+        node-version: [20, 22, 24, 26]
 
     steps:
       - name: Check out repo

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -25,9 +25,7 @@ declare namespace hapiScalar {
   }
 }
 
-declare const hapiScalar: {
-  plugin: Plugin<hapiScalar.RegisterOptions>
-}
+declare const hapiScalar: Plugin<hapiScalar.RegisterOptions>
 
-export { hapiScalar }
+export { hapiScalar as plugin }
 export default hapiScalar

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/inyourtime/hapi-scalar/issues"
   },
   "dependencies": {
-    "@scalar/client-side-rendering": "^0.1.4"
+    "@scalar/client-side-rendering": "^0.3.4"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.1.2",
@@ -46,8 +46,8 @@
     "@hapi/inert": "^7.1.0",
     "@hapi/vision": "^7.0.3",
     "@inyourtime/shared-configs": "^0.1.1",
-    "@types/node": "^25.0.2",
-    "c8": "^11.0.0",
+    "@types/node": "^26.1.1",
+    "c8": "^12.0.0",
     "hapi-swagger": "^17.3.2",
     "joi": "^17.13.3",
     "tstyche": "^7.0.0",

--- a/test-types/index.tst.ts
+++ b/test-types/index.tst.ts
@@ -48,7 +48,7 @@ server.register({
     routePrefix: '/scalar',
     scalarConfig: (request) => ({
       url: Array.isArray(request.query.customUrl)
-        ? request.query.customUrl[0]
+        ? request.query.customUrl[0] || '/default.json'
         : request.query.customUrl || '/default.json',
     }),
   },
@@ -64,7 +64,7 @@ server.register({
           () =>
             resolve({
               url: Array.isArray(request.query.customUrl)
-                ? request.query.customUrl[0]
+                ? request.query.customUrl[0] || '/async.json'
                 : request.query.customUrl || '/async.json',
             }),
           100,


### PR DESCRIPTION
## Summary

Fixes the TypeScript type tests by aligning the public declaration file with the runtime export shape. The default export is now typed as the Hapi plugin itself, and the named export matches the runtime `plugin` export.

Also updates the type test callbacks so `customUrl` array access falls back to a string, which keeps the tests compatible with `exactOptionalPropertyTypes`.

## Root Cause

The declaration file described the default export as a wrapped `{ plugin }` object even though `lib/index.js` exports the plugin object directly as default. Separately, indexed query-array access can produce `undefined`, which is not assignable to Scalar's optional `url?: string` property when exact optional property types are enabled.

## Validation

- `npm run test:typescript`
- `npm test`
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added reliable fallback URLs for synchronous and asynchronous Scalar configuration when a custom URL is unavailable.
- **Improvements**
  - Updated the plugin’s TypeScript declarations to provide a more direct plugin export and clearer named-export usage.
  - Enhanced compatibility with newer runtime environments and improved client-side rendering support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->